### PR TITLE
Enable user supplied req options

### DIFF
--- a/lib/defaults.cjs
+++ b/lib/defaults.cjs
@@ -7,6 +7,7 @@ const DEFAULT_OPTIONS = {
 	autoCorrect: false,
 	tld: 'com',
 	requestFunction(url, fetchinit) { return fetch(url, fetchinit); },
+	useUserSuppliedRequestOptions: false,
 	requestOptions: {
 		credentials: 'omit',
 		headers: {}	

--- a/lib/translation/batchTranslate.cjs
+++ b/lib/translation/batchTranslate.cjs
@@ -1,6 +1,6 @@
 'use strict';
 const { DEFAULT_OPTIONS, TRANSLATE_PATH } = require('../defaults.cjs');
-const { getRequestOptions } = require("./getRequestOptions.cjs")
+const { getRequestOptions } = require('./getRequestOptions.cjs');
 const TranslationResult = require('./TranslationResult.cjs');
 const { getCode } = require('../languages.cjs');
 

--- a/lib/translation/batchTranslate.cjs
+++ b/lib/translation/batchTranslate.cjs
@@ -1,5 +1,6 @@
 'use strict';
 const { DEFAULT_OPTIONS, TRANSLATE_PATH } = require('../defaults.cjs');
+const { getRequestOptions } = require("./getRequestOptions.cjs")
 const TranslationResult = require('./TranslationResult.cjs');
 const { getCode } = require('../languages.cjs');
 
@@ -24,8 +25,11 @@ module.exports = function (input, options) {
 		'rt': 'c'
 	});
 	const url = TRANSLATE_PATH + options.tld + '/_/TranslateWebserverUi/data/batchexecute?' + queryParams.toString();
+	const requestOptions = getRequestOptions(
+		options?.requestOptions ?? {}, 
+		DEFAULT_OPTIONS?.requestOptions ?? {},
+		options?.useUserSuppliedRequestOptions);
 
-	const requestOptions = {...options.requestOptions, ...DEFAULT_OPTIONS.requestOptions};
 	requestOptions.method = 'POST';
 	requestOptions.headers['Content-Type'] = 'application/x-www-form-urlencoded;charset=UTF-8';
 	

--- a/lib/translation/getRequestOptions.cjs
+++ b/lib/translation/getRequestOptions.cjs
@@ -1,0 +1,9 @@
+function getRequestOptions(reqOptions = {}, defaultReqOptions = {}, useUserSuppliedRequestOptions = false) {
+    if (useUserSuppliedRequestOptions === true) {
+		return reqOptions ?? {};
+	} 
+	
+    return {...reqOptions, ...defaultReqOptions};
+}
+
+module.exports = {getRequestOptions}

--- a/lib/translation/getRequestOptions.cjs
+++ b/lib/translation/getRequestOptions.cjs
@@ -6,4 +6,4 @@ function getRequestOptions(reqOptions = {}, defaultReqOptions = {}, useUserSuppl
     return {...reqOptions, ...defaultReqOptions};
 }
 
-module.exports = {getRequestOptions}
+module.exports = {getRequestOptions};

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "google-translate-api-x",
-      "version": "10.5.4",
+      "version": "10.6.7",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.25.0",

--- a/test/getRequestOptions.test.mjs
+++ b/test/getRequestOptions.test.mjs
@@ -1,22 +1,22 @@
 import assert from 'assert';
 import { getRequestOptions } from '../lib/translation/getRequestOptions.cjs';
-import { DEFAULT_OPTIONS } from "../lib/defaults.cjs"
+import { DEFAULT_OPTIONS } from '../lib/defaults.cjs';
 
 describe('getRequestOptions()', function () {
 
 	it('should result in default options', async () => {        
         const userDefinedOptions = {
-            "headers": {}
-        }
+            'headers': {}
+        };
 
-		const res = getRequestOptions(userDefinedOptions, DEFAULT_OPTIONS.requestOptions, false)
-        assert.deepEqual(res, DEFAULT_OPTIONS.requestOptions)
-    })
+		const res = getRequestOptions(userDefinedOptions, DEFAULT_OPTIONS.requestOptions, false);
+        assert.deepEqual(res, DEFAULT_OPTIONS.requestOptions);
+    });
 	it('should result in user-supplied options', async () => {
         const userDefinedOptions = {
-            "headers": {}
-        }
-		const res = getRequestOptions(userDefinedOptions, DEFAULT_OPTIONS.requestOptions, true)
-        assert.deepEqual(res, userDefinedOptions)
-    })
+            'headers': {}
+        };
+		const res = getRequestOptions(userDefinedOptions, DEFAULT_OPTIONS.requestOptions, true);
+        assert.deepEqual(res, userDefinedOptions);
+    });
 });

--- a/test/getRequestOptions.test.mjs
+++ b/test/getRequestOptions.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'assert';
+import { getRequestOptions } from '../lib/translation/getRequestOptions.cjs';
+import { DEFAULT_OPTIONS } from "../lib/defaults.cjs"
+
+describe('getRequestOptions()', function () {
+
+	it('should result in default options', async () => {        
+        const userDefinedOptions = {
+            "headers": {}
+        }
+
+		const res = getRequestOptions(userDefinedOptions, DEFAULT_OPTIONS.requestOptions, false)
+        assert.deepEqual(res, DEFAULT_OPTIONS.requestOptions)
+    })
+	it('should result in user-supplied options', async () => {
+        const userDefinedOptions = {
+            "headers": {}
+        }
+		const res = getRequestOptions(userDefinedOptions, DEFAULT_OPTIONS.requestOptions, true)
+        assert.deepEqual(res, userDefinedOptions)
+    })
+});


### PR DESCRIPTION
Hello! Thank you for the great library. I was attempting to use this in Cloudfare workers and it appears that for some unknown reason, they disallow the use of the `credentials` field in HTTP requests. This change enables the user to have more control over what request options are being used so that in the case of Cloudfare workers, the `credentials` field can be omitted.