### PR TITLE
Fix d.ts type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ The text to be translated, with optionally specific options for that text
 ### Returns an `object` | `object[]` | `{[key]: object}`}:
 Matches the structure of the input, so returns just the individual object if just a string is input, an array if an array is input, object with the same keys if an object is input.  Regardless of that, each returned value will have this schema:
 - `text` *(string)* – The translated text.
+- `pronunciation` *(string)* | *(undefined)* – Pronunciation guide (if available)
 - `from` *(object)*
   - `language` *(object)*
     - `didYouMean` *(boolean)* - `true` if the API suggest a correction in the source language

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,92 +4,123 @@
  */
 
 // Main export functions
-export default translate;
-export {
-	translate,
-	Translator,
-	speak,
-	singleTranslate,
-	batchTranslate,
-	languages,
-	isSupported,
-	getCode,
-};
+export = translate;
 
-// Namespace containing all type definitions and interfaces
-export declare namespace googleTranslateApi {
+/**
+ * Main translation function
+ * @param input - Text, array, or object of texts to translate
+ * @param opts - Translation options
+ * @returns Promise resolving to translation response(s)
+ */
+declare function translate<Input extends translate.Input>(
+	input: Input,
+	opts?: translate.RequestOptions,
+): translate.TranslationResponseStructure<Input>;
+
+declare namespace translate {
+	/**
+	 * Main translation function
+	 * @param input - Text, array, or object of texts to translate
+	 * @param opts - Translation options
+	 * @returns Promise resolving to translation response(s)
+	 */
+	export function translate<Input extends translate.Input>(
+		input: Input,
+		opts?: translate.RequestOptions,
+	): translate.TranslationResponseStructure<Input>;
+
 	/**
 	 * Options for translation requests
 	 */
 	interface TranslationOptions {
-		from?: string; // Source language
-		to?: string; // Target language
-		forceFrom?: boolean; // Force use of 'from' language
-		forceTo?: boolean; // Force use of 'to' language
-		autoCorrect?: boolean; // Enable auto-correction
+		/** The `text` language. Must be `auto` or one of the codes/names (not case sensitive) contained in [languages.cjs](https://github.com/AidanWelch/google-translate-api/blob/master/lib/languages.cjs) @default "auto" */
+		from?: string;
+		/** The language to which the text should be translated. Must be one of the codes/names (case sensitive!) contained in [languages.cjs](https://github.com/AidanWelch/google-translate-api/blob/master/lib/languages.cjs) @default "en" */
+		to?: string;
+		/** Forces the translate function to use the `from` option as the ISO code, without checking the languages list @default false */
+		forceFrom?: boolean;
+		/** Forces the translate function to use the `to` option as the ISO code, without checking the languages list @default false */
+		forceTo?: boolean;
+		/** Auto corrects the inputs, and uses those corrections in the translation @default false */
+		autoCorrect?: boolean;
 	}
 
 	/**
 	 * Extended options for API requests
 	 */
 	export interface RequestOptions extends TranslationOptions {
-		tld?: string; // Top-level domain for the translate host
-		requestFunction?: Function; // Custom request function
-		forceBatch?: boolean; // Force batch translation
-		fallbackBatch?: boolean; // Allow batch as fallback
-		requestOptions?: object; // Additional request options
-		rejectOnPartialFail?: boolean; // Reject on partial failure
+		/** TLD for Google translate host to be used in API calls: `https://translate.google.{tld}` @default "com" */
+		tld?: string;
+		/** Function inputs should take `(url, requestOptions)` and mimic the response of the Fetch API with a `res.text()` and `res.json()` method @default fetch */
+		requestFunction?: Function;
+		/** Forces the translate function to use the batch endpoint, which is less likely to be rate limited than the single endpoint @default true */
+		forceBatch?: boolean;
+		/** Enables falling back to the batch endpoint if the single endpoint fails @default true */
+		fallbackBatch?: boolean;
+		/** The options used by the `requestFunction`. Must be in the style of [fetchinit](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) */
+		requestOptions?: object;
+		/** When `true`, rejects whenever any translation in a batch fails—otherwise will just return `null` instead of that translation @default true */
+		rejectOnPartialFail?: boolean;
 	}
 
 	/**
 	 * Represents a translated language
 	 */
-	interface TranslatedLanguage {
-		didYouMean: boolean; // Indicates if this was a suggested language
-		iso: string; // ISO code of the language
+	export interface TranslatedLanguage {
+		/** `true` if the API suggested a correction in the source language */
+		didYouMean: boolean;
+		/** The [code of the language](https://github.com/AidanWelch/google-translate-api/blob/master/lib/languages.cjs) that the API has recognized in the `text` */
+		iso: string;
 	}
 
 	/**
 	 * Represents translated text
 	 */
-	interface TranslatedText {
-		autoCorrected: boolean; // Indicates if text was auto-corrected
-		value: string; // The translated text
-		didYouMean: boolean; // Indicates if this was a suggested translation
+	export interface TranslatedText {
+		/** `true` if the API has auto corrected the `text` */
+		autoCorrected: boolean;
+		/** The auto corrected `text` or the `text` with suggested corrections */
+		value: string;
+		/** `true` if the API has suggested corrections to the `text` and did not auto correct */
+		didYouMean: boolean;
 	}
 
 	/**
 	 * Response structure for a translation request
 	 */
 	export interface TranslationResponse {
-		text: string; // Translated text
-		pronunciation?: string; // Pronunciation guide (if available)
+		/** Translated text */
+		text: string;
+		/** Pronunciation guide (if available) */
+		pronunciation?: string;
 		from: {
 			language: TranslatedLanguage;
 			text: TranslatedText;
 		};
-		raw: string; // Raw response from the API
+		/** If `options.raw` is true, the raw response from Google Translate servers. Otherwise `''` */
+		raw: string;
 	}
 
 	/**
 	 * Query options for translation
 	 */
 	interface OptionQuery extends TranslationOptions {
-		text: string; // Text to translate
+		/** Text to translate */
+		text: string;
 	}
 
 	// Type aliases for various input formats
 	type Query = string | OptionQuery;
 	export type Input = string | Query[] | { [key: string]: Query };
 
-	// Type for translation response based on input type
+	/** Type for translation response based on input type */
 	export type TranslationResponseStructure<T> = T extends string
 		? Promise<TranslationResponse>
 		: T extends Query[]
 			? Promise<TranslationResponse[]>
 			: Promise<{ [key in keyof T]: TranslationResponse }>;
 
-	// Type for speak response based on input type
+	/** Type for speak response based on input type */
 	export type SpeakResponseStructure<T> = T extends string
 		? Promise<string>
 		: T extends Query[]
@@ -101,7 +132,7 @@ export declare namespace googleTranslateApi {
 	 * Generated from https://translate.google.com
 	 * See https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 	 */
-	export enum languages  {
+	export enum languages {
 		"auto" = "Detect language",
 		"ab" = "Abkhaz",
 		"ace" = "Acehnese",
@@ -184,6 +215,7 @@ export declare namespace googleTranslateApi {
 		"cnh" = "Hakha Chin",
 		"ha" = "Hausa",
 		"haw" = "Hawaiian",
+		"he" = "Hebrew",
 		"iw" = "Hebrew",
 		"hil" = "Hiligaynon",
 		"hi" = "Hindi",
@@ -348,88 +380,57 @@ export declare namespace googleTranslateApi {
 		"zu" = "Zulu",
 	}
 
-	namespace languages {
-		/**
-		 * Returns the ISO 639-1 code of the desired language
-		 * @param desiredLang - The name or code (case sensitive) of the desired language
-		 * @returns The ISO 639-1 code of the language or false if not supported
-		 */
-		function getCode(desiredLang: string): string | boolean;
-
-		/**
-		 * Checks if the desired language is supported by Google Translate
-		 * @param desiredLang - The ISO 639-1 code or name of the desired language
-		 * @returns True if supported, false otherwise
-		 */
-		function isSupported(desiredLang: string): boolean;
+	/**
+	 * Translator class for creating reusable translator instances
+	 */
+	export class Translator {
+		constructor(options?: RequestOptions);
+		translate<Input extends translate.Input>(
+			input: Input,
+			opts?: RequestOptions,
+		): TranslationResponseStructure<Input>;
+		options: RequestOptions;
 	}
-}
 
-/**
- * Main translation function
- * @param input - Text, array, or object of texts to translate
- * @param opts - Translation options
- * @returns Promise resolving to translation response(s)
- */
-declare function translate<Input extends googleTranslateApi.Input>(
-	input: Input,
-	opts?: googleTranslateApi.RequestOptions,
-): googleTranslateApi.TranslationResponseStructure<Input>;
-
-/**
- * Translator class for creating reusable translator instances
- */
-declare class Translator {
-	constructor(options?: googleTranslateApi.RequestOptions);
-	translate<Input extends googleTranslateApi.Input>(
+	/**
+	 * Function to get spoken audio of translated text
+	 * @param input - Text, array, or object of texts to speak
+	 * @param opts - Translation options, the `to` field is used for the language spoken in
+	 * @returns Promise resolving to Base64 string(s) encoding mp3 audio
+	 */
+	export function speak<Input extends translate.Input>(
 		input: Input,
-		opts?: googleTranslateApi.RequestOptions,
-	): googleTranslateApi.TranslationResponseStructure<Input>;
-	options: googleTranslateApi.RequestOptions;
+		opts?: RequestOptions,
+	): SpeakResponseStructure<Input>;
+
+	/**
+	 * Function to translate a single string
+	 * @param input - Text to translate
+	 * @param opts - Translation options
+	 * @returns Promise resolving to translation response
+	 */
+	export function singleTranslate(
+		input: string,
+		opts?: RequestOptions,
+	): TranslationResponseStructure<string>;
+
+	/**
+	 * Bypass any single translate options and forces batch translation
+	 */
+	export const batchTranslate: typeof translate;
+
+
+	/**
+	 * Returns true if the desiredLang is supported by Google Translate and false otherwise
+	 * @param desiredLang – the ISO 639-1 code or the name of the desired language
+	 * @returns True if supported, false otherwise
+	 */
+	export function isSupported(desiredLang: string): boolean;
+
+	/**
+	 * Returns the ISO 639-1 code of the desiredLang – if it is supported by Google Translate
+	 * @param desiredLang – the name or the code (case sensitive) of the desired language
+	 * @returns The ISO 639-1 code of the language or null if the language is not supported
+	 */
+	export function getCode(desiredLang: string): string | null;
 }
-
-/**
- * Function to get spoken audio of translated text
- * @param input - Text, array, or object of texts to speak
- * @param opts - Translation options
- * @returns Promise resolving to Base64 string(s) encoding mp3 audio
- */
-declare function speak<Input extends googleTranslateApi.Input>(
-	input: Input,
-	opts?: googleTranslateApi.RequestOptions,
-): googleTranslateApi.SpeakResponseStructure<Input>;
-
-/**
- * Function to translate a single string
- * @param input - Text to translate
- * @param opts - Translation options
- * @returns Promise resolving to translation response
- */
-declare function singleTranslate(
-	input: string,
-	opts?: googleTranslateApi.RequestOptions,
-): googleTranslateApi.TranslationResponseStructure<string>;
-
-/**
- * Bypass any single translate options and forces batch translation
- */
-declare const batchTranslate: typeof translate;
-
-/**
- * Object containing supported languages
- */
-declare const languages: typeof googleTranslateApi.languages;
-
-/**
- * Checks if a language is supported
- * @param desiredLang - Language to check
- * @returns True if supported, false otherwise
- */
-declare function isSupported(desiredLang: string): boolean;
-
-/**
- * Gets the language code for a given language name
- * @param desiredLang - Language name
- * @returns Language code if found, null otherwise
- */
-declare function getCode(desiredLang: string): string | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -215,7 +215,6 @@ declare namespace translate {
 		"cnh" = "Hakha Chin",
 		"ha" = "Hausa",
 		"haw" = "Hawaiian",
-		"he" = "Hebrew",
 		"iw" = "Hebrew",
 		"hil" = "Hiligaynon",
 		"hi" = "Hindi",

--- a/lib/languages.cjs
+++ b/lib/languages.cjs
@@ -261,8 +261,8 @@ const langs = {
 };
 /**
  * Returns the ISO 639-1 code of the desiredLang – if it is supported by Google Translate
- * @param {string} desiredLang – the name or the code(case sensitive) of the desired language
- * @returns {string|null} The ISO 639-1 code of the language or false if the language is not supported
+ * @param {string} desiredLang – the name or the code (case sensitive) of the desired language
+ * @returns {string|null} The ISO 639-1 code of the language or null if the language is not supported
  */
 function getCode(desiredLang) {
     if (typeof desiredLang !== 'string') {

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,15 +1,29 @@
-import { expectType } from 'tsd';
-import { translate, Translator, googleTranslateApi, speak } from '..';
+import { expectAssignable, expectType } from 'tsd';
+import translateDefaultImport, { translate, Translator, speak, TranslationResponse, singleTranslate, batchTranslate, isSupported, getCode, languages } from '..';
 
-expectType<Promise<googleTranslateApi.TranslationResponse>>(translate('abc'));
-expectType<Promise<googleTranslateApi.TranslationResponse[]>>(translate(['a', {text: 'b', to: 'nl'}, 'c']));
-expectType<Promise<{a: googleTranslateApi.TranslationResponse, b: googleTranslateApi.TranslationResponse}>>(translate({a: 'test', b: {text: 'b', to: 'nl'}}));
+// Expect assignable since the default import is a function with properties, i.e. `translateDefaultImport('text to translate', { to: 'nl' })` and `translateDefaultImport.isSupported('nl')` both work
+expectAssignable<typeof translate>(translateDefaultImport)
+expectType<typeof translateDefaultImport.translate>(translate)
+
+expectType<Promise<TranslationResponse>>(translate('abc'));
+expectType<Promise<TranslationResponse[]>>(translate(['a', {text: 'b', to: 'nl'}, 'c']));
+expectType<Promise<{a: TranslationResponse, b: TranslationResponse}>>(translate({a: 'test', b: {text: 'b', to: 'nl'}}));
 
 const translator = new Translator();
-expectType<Promise<googleTranslateApi.TranslationResponse>>(translator.translate('abc'));
-expectType<Promise<googleTranslateApi.TranslationResponse[]>>(translator.translate(['a', {text: 'b', to: 'nl'}, 'c']));
-expectType<Promise<{a: googleTranslateApi.TranslationResponse, b: googleTranslateApi.TranslationResponse}>>(translator.translate({a: 'test', b: {text: 'b', to: 'nl'}}));
+expectType<Promise<TranslationResponse>>(translator.translate('abc'));
+expectType<Promise<TranslationResponse[]>>(translator.translate(['a', {text: 'b', to: 'nl'}, 'c']));
+expectType<Promise<{a: TranslationResponse, b: TranslationResponse}>>(translator.translate({a: 'test', b: {text: 'b', to: 'nl'}}));
 
 expectType<Promise<string>>(speak('abc'));
 expectType<Promise<string[]>>(speak(['a', {text: 'b', to: 'nl'}, 'c']))
 expectType<Promise<{a: string, b: string}>>(speak({a: 'test', b: {text: 'b', to: 'nl'}}));
+
+expectType<Promise<TranslationResponse>>(singleTranslate('abc'));
+
+expectType<Promise<TranslationResponse>>(batchTranslate('abc'));
+expectType<Promise<TranslationResponse[]>>(batchTranslate(['a', {text: 'b', to: 'nl'}, 'c']));
+expectType<Promise<{a: TranslationResponse, b: TranslationResponse}>>(batchTranslate({a: 'test', b: {text: 'b', to: 'nl'}}));
+
+expectType<boolean>(isSupported('en'));
+expectType<string | null>(getCode('en'));
+expectAssignable<Record<string, string>>(languages);


### PR DESCRIPTION
I was using this library with my typescript project and I noticed some issues with the type definitions. I took a look into them and found both some issues from [Are the types wrong?](https://arethetypeswrong.github.io/?p=google-translate-api-x%4010.7.1) and trying to use the library:

## `languages` is not defined as `{[key]: string}`
The issue that made me look into the d.ts definitions in the first place, `languages` includes `.isSupported` and `.getCode` as properties.

![image](https://github.com/user-attachments/assets/9b171a8d-6394-4306-b4d4-7c90a75ccff9)
![image](https://github.com/user-attachments/assets/707137c4-ea36-4f9f-a769-633a2f6cf884)

Typescript will accept `languages.isSupported('en')` but that causes Node.js to crash when you actually run the code.

The issue is [`namespace languages`](https://github.com/AidanWelch/google-translate-api/blob/a60dbe8ffcc0726eab9eeb5dfdad3867b9315073/index.d.ts#L351) since it gets merged together with [`export enum languages`](https://github.com/AidanWelch/google-translate-api/blob/a60dbe8ffcc0726eab9eeb5dfdad3867b9315073/index.d.ts#L104C2-L104C25). The two functions in `namespace languages` are actually unused and [defined elsewhere](https://github.com/AidanWelch/google-translate-api/blob/a60dbe8ffcc0726eab9eeb5dfdad3867b9315073/index.d.ts#L423-L435) so you can remove the namespace and fix the issue without breaking anything.

## Exported `googleTranslateApi` namespace that doesn't exist
The [`export declare namespace googleTranslateApi`](https://github.com/AidanWelch/google-translate-api/blob/a60dbe8ffcc0726eab9eeb5dfdad3867b9315073/index.d.ts#L20) makes Typescript think there's an export called `googleTranslateApi` that you can import. Trying to import it causes Node.js to crash when you run the code.

![image](https://github.com/user-attachments/assets/c8ac3ad0-7941-4cdd-b87f-3908a75cfd51)

This is the "Named Exports" problem that Are the types wrong? reported. I replaced the export with `declare namespace translate` that also simplifies the exports since it gets merged with export `translate`.

## Incorrect default export

`export default translate` makes Typescript think you need an extra `.default` property:

![image](https://github.com/user-attachments/assets/75a487d7-17f6-4efd-85f4-cd807088cc92)

`translate.default(...)` however crashes because `.default` does not exist. Changing `export default` to `export = translate` causes `translate(...)` to be accepted and `translate.default(...)` to be rejected.

![image](https://github.com/user-attachments/assets/7c32f65d-9486-4f02-ba31-af53bc82c97e)

This makes Typescript accept all the [usage examples in the Readme](https://github.com/AidanWelch/google-translate-api?tab=readme-ov-file#usage).

## Extra changes

These changes make all the checks pass:

![image](https://github.com/user-attachments/assets/aa026b7b-3bc1-44f0-8ce3-05fed3d0977f)

But I also did some extra changes related to types:
- Added `pronunciation` to the readme.
  - It was in the types and is returned by the code, just not documented there.
- Changed d.ts comments to JSDoc comments.
  - This allows editors like VSCode to show the comments when you hover over things like `res.from.text.autoCorrected`.
- Extra d.ts tests
  - Added missing `singleTranslate`, `batchTranslate`, `isSupported`, `getCode`, `languages`, and default export to make sure future d.ts changes don't break these exports.
- Fixed `getCode` JSDoc saying it returns `the language or false` when it actually returns `the language or null`
- Export more types.
  - Export function argument and return types to avoid needing things like `ReturnType<typeof translate<string>>` and letting you use `TranslationResponse` instead.
  
This PR is _technically_ a breaking change since some code accepted by Typescript will now be rejected, but that accepted code would crash if you actually ran the program so it's more moving errors from run-time to compile-time instead of introducing new errors.